### PR TITLE
Remove `concat_idents` rust feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(concat_idents)]
 #![allow(clippy::missing_safety_doc)]
 
 mod core;


### PR DESCRIPTION
So this isn't actually required unless someone calls `entry_name!`: https://github.com/ProjectKML/render-pipeline-shaders-rs/blob/7c1f3384eb966cfb226b84da2c93fbae677eeb6c/src/core/api.rs#L275-L280

Everything else compiles fine under stable so I think that it'd be best to remove this feature and let downstream crates add it if they call `entry_name!`