### PR TITLE
Add a bunch of `into_raw` and `from_raw` helper functions

### DIFF
--- a/src/core/result.rs
+++ b/src/core/result.rs
@@ -41,6 +41,13 @@ impl Result {
     pub const CODE_COUNT: Self = Self(ffi::RpsResult_RPS_RESULT_CODE_COUNT);
 }
 
+impl Result {
+    #[inline]
+    pub fn into_raw(self) -> i32 {
+        self.0
+    }
+}
+
 impl Debug for Result {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/src/runtime/common/format.rs
+++ b/src/runtime/common/format.rs
@@ -126,6 +126,16 @@ impl Format {
 
 impl Format {
     #[inline]
+    pub fn from_raw(raw: u32) -> Self {
+        Self(raw)
+    }
+
+    #[inline]
+    pub fn into_raw(self) -> u32 {
+        self.0
+    }
+
+    #[inline]
     pub fn block_compressed(self) -> bool {
         unsafe { ffi::rpsFormatIsBlockCompressed(mem::transmute(self)) == TRUE }
     }

--- a/src/runtime/common/resource.rs
+++ b/src/runtime/common/resource.rs
@@ -20,6 +20,13 @@ impl ResourceType {
     pub const COUNT: Self = Self(ffi::RpsResourceType_RPS_RESOURCE_TYPE_COUNT as _);
 }
 
+impl ResourceType {
+    #[inline]
+    pub fn from_raw(raw: u32) -> Self {
+        Self(raw)
+    }
+}
+
 bitflags! {
     #[repr(transparent)]
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,6 +16,11 @@ macro_rules! define_handle {
 
         impl $name {
             #[inline]
+            pub fn from_raw(raw: *mut u8) -> Self {
+                Self(raw)
+            }
+
+            #[inline]
             pub fn into_raw(self) -> *mut u8 {
                 self.0
             }


### PR DESCRIPTION
These aren't _strictly_ needed as you call `transmute` in their place, but they're a bit nicer. Happy to rename `into_ffi` and `from_ffi` is that works out better. 